### PR TITLE
Unpacks Quicklinks in Prosilver

### DIFF
--- a/styles/prosilver/template/navbar_header.html
+++ b/styles/prosilver/template/navbar_header.html
@@ -14,35 +14,9 @@
 
 					<!-- IF S_DISPLAY_SEARCH -->
 						<li class="separator"></li>
-						<!-- IF S_REGISTERED_USER -->
-							<li>
-								<a href="{U_SEARCH_SELF}" role="menuitem">
-									<i class="icon fa-file-o fa-fw icon-gray" aria-hidden="true"></i><span>{L_SEARCH_SELF}</span>
-								</a>
-							</li>
-						<!-- ENDIF -->
-						<!-- IF S_USER_LOGGED_IN -->
-							<li>
-								<a href="{U_SEARCH_NEW}" role="menuitem">
-									<i class="icon fa-file-o fa-fw icon-red" aria-hidden="true"></i><span>{L_SEARCH_NEW}</span>
-								</a>
-							</li>
-						<!-- ENDIF -->
-						<!-- IF S_LOAD_UNREADS -->
-							<li>
-								<a href="{U_SEARCH_UNREAD}" role="menuitem">
-									<i class="icon fa-file-o fa-fw icon-red" aria-hidden="true"></i><span>{L_SEARCH_UNREAD}</span>
-								</a>
-							</li>
-						<!-- ENDIF -->
-							<li>
-								<a href="{U_SEARCH_UNANSWERED}" role="menuitem">
-									<i class="icon fa-file-o fa-fw icon-gray" aria-hidden="true"></i><span>{L_SEARCH_UNANSWERED}</span>
-								</a>
-							</li>
-							<li>
-								<a href="{U_SEARCH_ACTIVE_TOPICS}" role="menuitem">
-									<i class="icon fa-file-o fa-fw icon-blue" aria-hidden="true"></i><span>{L_SEARCH_ACTIVE_TOPICS}</span>
+							<li <!-- IF not S_USER_LOGGED_IN -->data-skip-responsive="true"<!-- ELSE -->data-last-responsive="true"<!-- ENDIF -->>
+								<a href="{U_FAQ}" rel="help" title="{L_FAQ_EXPLAIN}" role="menuitem">
+									<i class="icon fa-question-circle fa-fw" aria-hidden="true"></i><span>{L_FAQ}</span>
 								</a>
 							</li>
 							<li class="separator"></li>
@@ -78,11 +52,37 @@
 		</li>
 
 		<!-- EVENT overall_header_navigation_prepend -->
-		<li <!-- IF not S_USER_LOGGED_IN -->data-skip-responsive="true"<!-- ELSE -->data-last-responsive="true"<!-- ENDIF -->>
-			<a href="{U_FAQ}" rel="help" title="{L_FAQ_EXPLAIN}" role="menuitem">
-				<i class="icon fa-question-circle fa-fw" aria-hidden="true"></i><span>{L_FAQ}</span>
-			</a>
-		</li>
+		<!-- IF S_LOAD_UNREADS -->
+			<li>
+				<a href="{U_SEARCH_UNREAD}" role="menuitem">
+					<i class="icon fa-file-o fa-fw icon-red" aria-hidden="true"></i><span>{L_SEARCH_UNREAD}</span>
+				</a>
+			</li>
+		<!-- ENDIF -->
+		<!-- IF S_USER_LOGGED_IN -->
+			<li>
+				<a href="{U_SEARCH_NEW}" role="menuitem">
+					<i class="icon fa-file-o fa-fw icon-red" aria-hidden="true"></i><span>{L_SEARCH_NEW}</span>
+				</a>
+			</li>
+		<!-- ENDIF -->
+			<li>
+				<a href="{U_SEARCH_UNANSWERED}" role="menuitem">
+					<i class="icon fa-file-o fa-fw icon-gray" aria-hidden="true"></i><span>{L_SEARCH_UNANSWERED}</span>
+				</a>
+			</li>
+			<li>
+				<a href="{U_SEARCH_ACTIVE_TOPICS}" role="menuitem">
+					<i class="icon fa-file-o fa-fw icon-blue" aria-hidden="true"></i><span>{L_SEARCH_ACTIVE_TOPICS}</span>
+				</a>
+			</li>
+		<!-- IF S_REGISTERED_USER -->
+			<li>
+				<a href="{U_SEARCH_SELF}" role="menuitem">
+					<i class="icon fa-file-o fa-fw icon-gray" aria-hidden="true"></i><span>{L_SEARCH_SELF}</span>
+				</a>
+			</li>
+		<!-- ENDIF -->
 		<!-- EVENT overall_header_navigation_append -->
 		<!-- IF U_ACP -->
 			<li data-last-responsive="true">


### PR DESCRIPTION
Quite a few of our forum users don't know about quicklinks or how useful they are and I found out that actually that's just a bunch of searches and you can unpack them into the navbar proper. So I swapped them for the FAQ. 

Searches like "New Posts" are how we can spotlight activity on the forums and build momentum. Making them immediately accessible and not behind a drop down is a crucial step up to overall forum activity and cross-pollination.

I do not have a way to preview this correctly but looking at the raw HTML sheet preview it seemed fine. All I did was move code around so everything should be fine and if not easily reversible.

Navbar_Header in Prosilver is inherited by the other styles

55-85 might need to be detabbed or tabbed by one? Not sure.

Puts FAQ in Quicklinks.
Pulls out Unreads, New Posts, Unanswered Topics, Active Topics, and Your Posts. In that Order. ACP and MCP move further to the right.

Not sure how long this is going to be actually, might need to reduce but the contrast and tinker will be nice. I'll be available to tinker on it further.