### PR TITLE
Header/Footer tweaks.

### DIFF
--- a/styles/tg_silver/template/navbar_footer.html
+++ b/styles/tg_silver/template/navbar_footer.html
@@ -48,10 +48,6 @@
 			<!-- ENDIF -->
 		<!-- ENDIF -->
 		<!-- EVENT overall_footer_teamlink_before -->
-			<li class="rightside" data-last-responsive="true">
-				<span class="navlink2"><a href="https://github.com/tgstation/tgstation">TG Codebase</a></span>
-				<span class="navlink2"><a href="https://github.com/tgstation-operations/server-config">Server Config</a></span>
-			</li>
 		<!-- IF U_TEAM -->
 			<li class="rightside" data-last-responsive="true">
 				<a href="{U_TEAM}" role="menuitem">
@@ -59,6 +55,10 @@
 				</a>
 			</li>
 		<!-- ENDIF -->
+			<li class="rightside" data-last-responsive="true">
+				<span class="navlink2"><a href="https://github.com/tgstation/tgstation">TG Codebase</a></span>
+				<span class="navlink2"><a href="https://github.com/tgstation-operations/server-config">Server Config</a></span>
+			</li>
 		<!-- EVENT overall_footer_teamlink_after -->
 		<!-- IF U_CONTACT_US -->
 			<li class="rightside" data-last-responsive="true">

--- a/styles/tg_silver/template/navbar_header.html
+++ b/styles/tg_silver/template/navbar_header.html
@@ -52,13 +52,6 @@
 		</li>
 
 		<!-- EVENT overall_header_navigation_prepend -->
-		<!-- IF S_LOAD_UNREADS -->
-			<li>
-				<a href="{U_SEARCH_UNREAD}" role="menuitem">
-					<i class="icon fa-file-o fa-fw icon-red" aria-hidden="true"></i><span>{L_SEARCH_UNREAD}</span>
-				</a>
-			</li>
-		<!-- ENDIF -->
 		<!-- IF S_USER_LOGGED_IN -->
 			<li>
 				<a href="{U_SEARCH_NEW}" role="menuitem">
@@ -66,14 +59,21 @@
 				</a>
 			</li>
 		<!-- ENDIF -->
+		<!-- IF S_LOAD_UNREADS -->
 			<li>
-				<a href="{U_SEARCH_UNANSWERED}" role="menuitem">
-					<i class="icon fa-file-o fa-fw icon-gray" aria-hidden="true"></i><span>{L_SEARCH_UNANSWERED}</span>
+				<a href="{U_SEARCH_UNREAD}" role="menuitem">
+					<i class="icon fa-file-o fa-fw icon-red" aria-hidden="true"></i><span>{L_SEARCH_UNREAD}</span>
 				</a>
 			</li>
+		<!-- ENDIF -->
 			<li>
 				<a href="{U_SEARCH_ACTIVE_TOPICS}" role="menuitem">
 					<i class="icon fa-file-o fa-fw icon-blue" aria-hidden="true"></i><span>{L_SEARCH_ACTIVE_TOPICS}</span>
+				</a>
+			</li>
+			<li>
+				<a href="{U_SEARCH_UNANSWERED}" role="menuitem">
+					<i class="icon fa-file-o fa-fw icon-gray" aria-hidden="true"></i><span>{L_SEARCH_UNANSWERED}</span>
 				</a>
 			</li>
 		<!-- IF S_REGISTERED_USER -->
@@ -214,11 +214,11 @@
 			</li>
 		{% endif %}
 		<li class="navlinks2 rightside">
-			<span class="navlink2"><a href="https://tgstation13.org/">Site Home</a></span>
+			<span class="navlink2"><a href="https://forums.tgstation13.org/viewtopic.php?t=38960">Donate</a></span>
+			<span class="navlink2"><a href="https://spacestationidle.com/">SS13 Idle</a></span>
+			<span class="navlink2"><a href="https://statbus.space/">Statbus</a></span>
 			<span class="navlink2"><a href="https://wiki.tgstation13.org/">Wiki</a></span>
-			<span class="navlink2" style="text-shadow:0 0 1em #4f91b6,0 0 1em #4f91b6,0 0 1.2em #4f91b6"><a href="https://forums.tgstation13.org/viewtopic.php?t=38960">Donate</a></span>
-			<span class="navlink2" style="text-shadow:0 0 1em #4f91b6,0 0 1em #4f91b6,0 0 1.2em #4f91b6"><a href="https://statbus.space/">Statbus</a></span>
-			<span class="navlink2" style="text-shadow:0 0 1em #4f91b6,0 0 1em #4f91b6,0 0 1.2em #4f91b6"><a href="https://spacestationidle.com/">Space Station Idle</a></span>
+			<span class="navlink2"><a href="https://tgstation13.org/">Site Home</a></span>
 		</li>
 	</ul>
 	


### PR DESCRIPTION
Moves Active Topics to the middle of the 5, removes glow/shadow from right-side links, re-arranges right-side links to: Donate, SS13 Idle, Statbus, Wiki, Site Home

Arranges footer to: TG Codebase, Server Config, The team...