### PR TITLE
Fix display last post extension

### DIFF
--- a/ext/aurelienazerty/displaylastpost/event/listener.php
+++ b/ext/aurelienazerty/displaylastpost/event/listener.php
@@ -115,6 +115,7 @@ class listener implements EventSubscriberInterface
 		if ($sort_key == 't' && $this->config['display_last_post_show'] && $start > 0)
 		{
 			$new_post_list = array();
+			$new_post_list[0] = null;
 			foreach ($post_list as $key => $value)
 			{
 				$new_post_list[$key+1] = $value;


### PR DESCRIPTION
adding that first element to 0 prevents $new_post_list from turning into an object with all the assignments to index 1 and onwards